### PR TITLE
NO_RESPONSE hotfix

### DIFF
--- a/lib/utils/ServiceUtils.js
+++ b/lib/utils/ServiceUtils.js
@@ -69,6 +69,7 @@ module.exports = function(node) {
 
                 if (msg.payload[key] === noResponseMsg) {
                     node.accessory.updateReachability(false);
+                    characteristic.setValue(new Error(noResponseMsg));
 
                     return;
                 }


### PR DESCRIPTION
> It turned out that setting characteristic with Error object was not redundant for NO_RESPONSE status. The light switch worked as expected, however setting NO_RESPONSE status for temperature and humidity sensors was broken. This PR fixes the issue.

~ @radionoise 