### PR TITLE
Add CHANGELOG file to repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# Change Log
+# Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.2]
-
-Hotfix for NO_RESPONSE
+## [0.6.2] - 2019.03.27
+### Fixed
+ - Hotfix for "NO_RESPONSE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+
+## [0.6.2]
+
+Hotfix for NO_RESPONSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.6.2] - 2019.03.27
+### Changed
+ - Some minor changes in README
+
 ### Fixed
  - Hotfix for "NO_RESPONSE"
+
+ 
+## [0.6.1] - 2019.03.21
+### Added
+ - Reintroduced DEBUG mode (DEBUG=NRCHKB node-red)
+
+### Changed
+ - Renaming organisation
+ - Minor changes to process of finding Parent Service as Linked Service
+
+### Fixed
+ - Crash upon removing bridge from Home [#22](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/22)
+ - Fix: "Error: This callback function has already been called by someone else..." [#66](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/66)
+
+
+## [0.6.0] - 2019.03.16
+### Added
+ - Introduce Linked Services [#41](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/41)
+ - MDNS Configuration [#44](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/44)
+ - Filter on Topic
+ - NO_RESPONSE trigger [#48](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/48)
+ - onIdentify [#54](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/54)
+ - Added automatic tests for building project, code quality and finding vulnerabilites
+ 
+### Changed
+ - Redesigned README


### PR DESCRIPTION
I have added a simple Changelog file to the repository. If we add all further updates to this file, it will be easier for users to track what changed/fixed in the releases. 

Also as I saw, maybe we could add this to show up in the Node-RED palette, when updating this addon from the GUI.