### PR TITLE
Update CharacteristicUtils.js

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: "[BUG]"
 labels: 'bug :bug:'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: "[FEATURE]"
 labels: 'enhancement :+1:'
 assignees: ''
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # node-red-contrib-homekit-bridged
 
-|master [![Build Status](https://travis-ci.org/NRCHKB/node-red-contrib-homekit-bridged.svg?branch=master)](https://travis-ci.org/NRCHKB/node-red-contrib-homekit-bridged) [![codebeat badge](https://codebeat.co/badges/3bbdea35-c2ab-4273-b5d7-de6c4c9c1971)](https://codebeat.co/projects/github-com-nrchkb-node-red-contrib-homekit-bridged-master) [![Known Vulnerabilities](https://snyk.io/test/github/NRCHKB/node-red-contrib-homekit-bridged/badge.svg?targetFile=package.json)](https://snyk.io/test/github/NRCHKB/node-red-contrib-homekit-bridged?targetFile=package.json)|dev [![Build Status](https://travis-ci.org/NRCHKB/node-red-contrib-homekit-bridged.svg?branch=dev)](https://travis-ci.org/NRCHKB/node-red-contrib-homekit-bridged) [![codebeat badge](https://codebeat.co/badges/e483faf0-923d-4916-9412-f2117206bdcf)](https://codebeat.co/projects/github-com-nrchkb-node-red-contrib-homekit-bridged-dev)|
-|-|-|
+[![Build Status](https://travis-ci.org/NRCHKB/node-red-contrib-homekit-bridged.svg?branch=master)](https://travis-ci.org/NRCHKB/node-red-contrib-homekit-bridged) [![codebeat badge](https://codebeat.co/badges/3bbdea35-c2ab-4273-b5d7-de6c4c9c1971)](https://codebeat.co/projects/github-com-nrchkb-node-red-contrib-homekit-bridged-master) [![Known Vulnerabilities](https://snyk.io/test/github/NRCHKB/node-red-contrib-homekit-bridged/badge.svg?targetFile=package.json)](https://snyk.io/test/github/NRCHKB/node-red-contrib-homekit-bridged?targetFile=package.json)
 
 ## Intro
 

--- a/lib/utils/CharacteristicUtils.js
+++ b/lib/utils/CharacteristicUtils.js
@@ -21,6 +21,7 @@ module.exports = function(node) {
 
                 if (characteristic && characteristicProperties[key]) {
                     characteristic.setProps(characteristicProperties[key]);
+                    characteristic.setValue(characteristicProperties[key]);
                 }
             }
         }
@@ -39,7 +40,7 @@ module.exports = function(node) {
             const cKey = characteristic.displayName
                 .replace(/ /g, "")
                 .replace(/\./g, "_");
-            if (characteristic.props.perms.indexOf("pw") > -1) {
+            if (characteristic.props.perms.indexOf("pr") > -1) {
                 supported.read.push(cKey);
 
                 // Subscribe to 'get' event of readable characteristic
@@ -52,10 +53,7 @@ module.exports = function(node) {
                 });
             }
 
-            if (
-                characteristic.props.perms.indexOf("pr") +
-                characteristic.props.perms.indexOf("ev") >
-                -2
+            if (characteristic.props.perms.indexOf("pw") > -1
             ) {
                 supported.write.push(cKey);
                 

--- a/lib/utils/ServiceUtils.js
+++ b/lib/utils/ServiceUtils.js
@@ -69,6 +69,7 @@ module.exports = function(node) {
 
                 if (msg.payload[key] === noResponseMsg) {
                     node.accessory.updateReachability(false);
+                    characteristic.setValue(new Error(noResponseMsg));
 
                     return;
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-homekit-bridged",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -87,6 +87,16 @@
         "xml2js": "0.4.19"
       },
       "dependencies": {
+        "js-yaml": {
+          "version": "3.12.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+          "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "media-typer": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.0.1.tgz",
@@ -3425,9 +3435,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-homekit-bridged",
-  "version": "0.6.1",
-  "description": "Node-RED nodes to simulate Apple HomeKit devices. Based on node-red-contrib-homekit, but with support for bridged devices.",
+  "version": "0.6.2",
+  "description": "Node-RED nodes to simulate Apple HomeKit devices.",
   "main": "homekit.js",
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
This one handle two change. One correcting characteristic permission handler. Another to enable init (or persistent for pv only) value from Characteristic Properties.

The handling of characteristic permission may wrongly. Propose to do follow:

If PERM.READ (i.e. pv or PAIRED-READ) available, enable "get" event
If PERM.WRITE (i.e. pw or PAIRED-WRITE) available, enable "set" event
Remark: No consider PERM.NOTIFY (i.e. ev or EVENT), not necessary for this node emulation.
Some characteristic are read only, like Characteristic.Manufacturer, Characteristic.Identifier etc.
These characteristic should init when the node created.

Here is the example.
<img width="979" alt="Screenshot 2019-04-05 at 10 52 06 PM" src="https://user-images.githubusercontent.com/26063869/55663542-f48d3180-5851-11e9-8fe3-d8af81ad6f90.png">
[flows.json.txt](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/files/3050061/flows.json.txt)

