### PR TITLE
0.8.0 - add hap.context in node output and Allow Message Passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.2] - 2019.10.13
+## [0.8.0] - 2019.10.14
 ### Added
  - Added greenkeeper
  - Added setting to Bidge configuration called Allow Message Passthrough

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2019.10.13
+### Added
+ - Added greenkeeper
+### Changed
+ - Updated README
+### Fixed
+ - Revert hap.context in output
+
+
+## [0.7.1] - 2019.10.13
+### Fixed
+ - Added labels to node outputs as there are new output for camera snapshot
+
 ## [0.7.0] - 2019.10.12
 ### Added
  - CHANGELOG page introduction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.2] - 2019.10.13
 ### Added
  - Added greenkeeper
+ - Added setting to Bidge configuration called Allow Message Passthrough
 ### Changed
  - Updated README
 ### Fixed
- - Revert hap.context in output
+ - Revert hap.context in node output
 
 
 ## [0.7.1] - 2019.10.13

--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ The following is a list of _Services_ that are currently supported. Check for mo
 - Window
 - WindowCovering
 
+## Context
+
+Context info can be provided as part of the input message and will be available in the output message as `hap.context`.
+
+**Example**:
+
+```json
+{
+  "On": 1,
+  "Context": "set_from_mqtt_topic"
+}
+```
+
 ## No Response
 
 You can set accessory "No Response" status by sending "NO_RESPONSE" as a value for any available characteristic.
@@ -212,6 +225,16 @@ This should output detailed information regarding everything in the homekit cont
 #### The same command gets sent over and over. How do I stop that?
 
 The built in `rbe` node may be placed as needed to only pass on messages if they are different from previous messages. 
+
+#### I only want to get messages when something has been changed in the Home app, but also all messages I send into the homekit node get forwarded, too. How do I stop that?
+
+Insert this node right after your homekit node:
+
+```
+[{"id":"","type":"switch","z":"","name":"check hap.context","property":"hap.context","propertyType":"msg","rules":[{"t":"nnull"}],"checkall":"true","repair":false,"outputs":1,"x":0,"y":0,"wires":[]}]
+```
+
+This will filter out all messages with their payload property hap.context not set, which means they are events that have been sent to homekit via node-red, not via the Home app.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All accessories behind a bridge noded are then automatically added by iOS.
 - **Allow Insecure Request**: Should we allow insecure request? Default false.
 - **Manufacturer, Model, Serial Number**: Can be anything you want.
 - **Name**: Can be anything you want.
+- **Allow Message Passthrough**: If you allow then message from node input will be send to node output.
 - **Custom MDNS Configuration**: Check if you would like to use custom MDNS configuration.
   - **Multicast**: Use udp multicasting. Optional. Default true.
   - **Multicast Interface IP**: Explicitly specify a network interface. Optional. Defaults to all.
@@ -227,6 +228,8 @@ This should output detailed information regarding everything in the homekit cont
 The built in `rbe` node may be placed as needed to only pass on messages if they are different from previous messages. 
 
 #### I only want to get messages when something has been changed in the Home app, but also all messages I send into the homekit node get forwarded, too. How do I stop that?
+
+Set Allow Message Passthrough to false in the Bridge configuration or...
 
 Insert this node right after your homekit node:
 

--- a/README.md
+++ b/README.md
@@ -116,52 +116,58 @@ Output messages are in the same format as input messages. They are emitted from 
 
 The following is a list of _Services_ that are currently supported. Check for more details on [the wiki](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/wiki/Services). If you encounter problems with any of them please file an Issue.
 
-- Air Quality Sensor
-- Battery Service
-- Camera Control
-- Camera RTP Stream Management
-- Carbon Dioxide Sensor
-- Carbon Monoxide Sensor
-- Contact Sensor
+- AccessoryInformation
+- AirPurifier
+- AirQualitySensor
+- BatteryService
+- BridgeConfiguration
+- BridgingState
+- CameraControl
+- CameraRTPStreamManagement
+- CarbonDioxideSensor
+- CarbonMonoxideSensor
+- ContactSensor
 - Door
 - Doorbell
 - Fan
-- Garage Door Opener
-- Humidity Sensor
-- Leak Sensor
-- Light Sensor
+- Fanv2
+- Faucet
+- FilterMaintenance
+- GarageDoorOpener
+- HeaterCooler
+- HumidifierDehumidifier
+- HumiditySensor
+- InputSource
+- IrrigationSystem
+- LeakSensor
+- LightSensor
 - Lightbulb
-- Lock Management
-- Lock Mechanism
+- LockManagement
+- LockMechanism
 - Microphone
-- Motion Sensor
-- Occupancy Sensor
+- MotionSensor
+- OccupancySensor
 - Outlet
+- Pairing
+- ProtocolInformation
 - Relay
-- Security System
-- Smoke Sensor
+- SecuritySystem
+- ServiceLabel
+- Slat
+- SmokeSensor
 - Speaker
-- Stateful Programmable Switch
-- Stateless Programmable Switch
+- StatefulProgrammableSwitch
+- StatelessProgrammableSwitch
 - Switch
-- Temperature Sensor
+- Television
+- TelevisionSpeaker
+- TemperatureSensor
 - Thermostat
-- Time Information
+- TimeInformation
+- TunneledBTLEAccessoryService
+- Valve
 - Window
-- Window Covering
-
-## Context
-
-Context info can be provided as part of the input message and will be available in the output message as `hap.context`.
-
-**Example**:
-
-```json
-{
-  "On": 1,
-  "Context": "set_from_mqtt_topic"
-}
-```
+- WindowCovering
 
 ## No Response
 
@@ -206,17 +212,6 @@ This should output detailed information regarding everything in the homekit cont
 #### The same command gets sent over and over. How do I stop that?
 
 The built in `rbe` node may be placed as needed to only pass on messages if they are different from previous messages. 
-
-#### I only want to get messages when something has been changed in the Home app, but also all messages I send into the homekit node get forwarded, too. How do I stop that?
-
-Insert this node right after your homekit node:
-
-```
-[{"id":"","type":"switch","z":"","name":"check hap.context","property":"hap.context","propertyType":"msg","rules":[{"t":"nnull"}],"checkall":"true","repair":false,"outputs":1,"x":0,"y":0,"wires":[]}]
-```
-
-This will filter out all messages with their payload property hap.context not set, which means they are events that have been sent to homekit via node-red, not via the Home app.
-
 
 ## Contributors
 

--- a/homekit.html
+++ b/homekit.html
@@ -279,7 +279,7 @@
     <hr>
     <div class="form-row">
         <input type="checkbox" id="node-config-input-allowMessagePassthrough" style="display: inline-block; width: auto; vertical-align: top;">
-        <label for="node-config-input-allowMessagePassthrough" style="width: 70%;">&nbsp;&nbsp;<i class="fa fa-shield"></i> Allow Message Passthrough</label>
+        <label for="node-config-input-allowMessagePassthrough" style="width: 70%;">&nbsp;&nbsp;<i class="fa fa-step-forward"></i> Allow Message Passthrough</label>
     </div>
     <hr>
     <div class="form-row">

--- a/homekit.html
+++ b/homekit.html
@@ -278,6 +278,11 @@
     </div>
     <hr>
     <div class="form-row">
+        <input type="checkbox" id="node-config-input-allowMessagePassthrough" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-config-input-allowMessagePassthrough" style="width: 70%;">&nbsp;&nbsp;<i class="fa fa-shield"></i> Allow Message Passthrough</label>
+    </div>
+    <hr>
+    <div class="form-row">
         <input type="checkbox" id="node-config-input-customMdnsConfig" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-config-input-customMdnsConfig" style="width: 70%;">&nbsp;&nbsp;<i class="fa fa-filter"></i> Custom MDNS Configuration</label>
     </div>
@@ -324,6 +329,7 @@
         <li><strong>Allow Insecure Request</strong>: Should we allow insecure request? Default false.</li>
         <li><strong>Manufacturer, Model, Serial Number</strong>: Can be anything you want.</li>
         <li><strong>Name</strong>: If you intend to simulate a rocket, then why don&#39;t you call it <em>Rocket</em>.</li>
+        <li><strong>Allow Message Passthrough</strong>: If you allow then message from node input will be send to node output.</li>
         <li><strong>Custom MDNS Configuration</strong>: Check if you would like to use custom mdns configuration.</li>
         <ul>
             <li><strong>Multicast</strong>: Use udp multicasting. Optional. Default true.</li>
@@ -749,6 +755,10 @@
             mdnsReuseAddr: {
                 value: true,
                 required: false
+            },
+            allowMessagePassthrough: {
+                value: true,
+                required: true
             }
         },
         label: function() {
@@ -758,6 +768,11 @@
             return this.bridgeName ? "node_label_italic" : "";
         },
         oneditprepare: function () {
+            if (typeof this.allowMessagePassthrough == "undefined") {
+                this.allowMessagePassthrough = true
+                $("#node-config-input-allowMessagePassthrough").prop('checked', true);
+            }
+
             let customMdnsConfigCheckbox = $("#node-config-input-customMdnsConfig");
             let mdnsConfiguration = $("#mdns-configuration");
 

--- a/lib/HAPBridgeNode.js
+++ b/lib/HAPBridgeNode.js
@@ -19,8 +19,10 @@ module.exports = function(RED) {
 
         this.pinCode = config.pinCode
         this.port = config.port
-        this.allowInsecureRequest = config.allowInsecureRequest || false
+        this.allowInsecureRequest = config.allowInsecureRequest !== undefined ? config.allowInsecureRequest : false
 
+        this.allowMessagePassthrough = config.allowMessagePassthrough !== undefined ? config.allowMessagePassthrough : false
+        
         this.manufacturer = config.manufacturer
         this.serialNo = config.serialNo
         this.model = config.model

--- a/lib/utils/CharacteristicUtils.js
+++ b/lib/utils/CharacteristicUtils.js
@@ -55,7 +55,8 @@ module.exports = function(node) {
                 }
             })
 
-            characteristic.on('set', ServiceUtils.onCharacteristicChange)
+            characteristic.on('set', ServiceUtils.onCharacteristicSet)
+            characteristic.on('change', ServiceUtils.onCharacteristicChange)
 
             //TODO: Remove when persist table is here
             //Allow for negative temperatures

--- a/lib/utils/ServiceUtils.js
+++ b/lib/utils/ServiceUtils.js
@@ -7,12 +7,16 @@ module.exports = function(node) {
 
     const CameraSource = require('../cameraSource').Camera
 
-    const onCharacteristicChange = function(info, callback) {
+    const onCharacteristicChange = function(info, callback, context) {
         const topic = node.topic ? node.topic : node.topic_in
-        const msg = { payload: {}, name: node.name, topic: topic }
+        const msg = { payload: {}, hap: {}, name: node.name, topic: topic }
         const key = this.displayName.replace(/ /g, '').replace(/\./g, '_')
 
         msg.payload[key] = info
+
+        if (context) {
+            msg.hap.context = context
+        }
 
         node.status({
             fill: 'yellow',

--- a/lib/utils/ServiceUtils.js
+++ b/lib/utils/ServiceUtils.js
@@ -38,7 +38,9 @@ module.exports = function(node) {
 
         debug(node.name + ' received ' + key + ': ' + newValue)
 
-        node.send(msg)
+        if (context || node.bridgeNode.allowMessagePassthrough) {
+            node.send(msg)
+        }
     }
 
     const onInput = function(msg) {

--- a/lib/utils/ServiceUtils.js
+++ b/lib/utils/ServiceUtils.js
@@ -7,31 +7,38 @@ module.exports = function(node) {
 
     const CameraSource = require('../cameraSource').Camera
 
-    const onCharacteristicChange = function(info, callback, context) {
+    const onCharacteristicSet = function(newValue, callback, context) {
+        callback(node.accessory.reachable === true ? null : 'no response')
+    }
+
+    const onCharacteristicChange = function({oldValue, newValue, context}) {
         const topic = node.topic ? node.topic : node.topic_in
         const msg = { payload: {}, hap: {}, name: node.name, topic: topic }
         const key = this.displayName.replace(/ /g, '').replace(/\./g, '_')
 
-        msg.payload[key] = info
+        msg.payload[key] = newValue
 
         if (context) {
-            msg.hap.context = context
+            msg.hap = {
+                oldValue: oldValue,
+                newValue: newValue,
+                context: context,
+            }
         }
 
         node.status({
             fill: 'yellow',
             shape: 'dot',
-            text: key + ': ' + info,
+            text: key + ': ' + newValue,
         })
 
         setTimeout(function() {
             node.status({})
         }, 3000)
 
-        debug(node.name + ' received ' + key + ': ' + info)
+        debug(node.name + ' received ' + key + ': ' + newValue)
 
         node.send(msg)
-        callback(node.accessory.reachable === true ? null : 'no response')
     }
 
     const onInput = function(msg) {
@@ -217,6 +224,7 @@ module.exports = function(node) {
 
     return {
         getOrCreate: getOrCreate,
+        onCharacteristicSet: onCharacteristicSet,
         onCharacteristicChange: onCharacteristicChange,
         onInput: onInput,
         onClose: onClose,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-homekit-bridged",
-    "version": "0.7.2",
+    "version": "0.8.0",
     "description": "Node-RED nodes to simulate Apple HomeKit devices.",
     "main": "homekit.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-homekit-bridged",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "Node-RED nodes to simulate Apple HomeKit devices.",
     "main": "homekit.js",
     "scripts": {


### PR DESCRIPTION
### Added
 - Added greenkeeper
 - Added setting to Bidge configuration called Allow Message Passthrough
### Changed
 - Updated README
### Fixed
 - Revert hap.context in node output