### PR TITLE
1.0.0-dev.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Corrections regarding issue [#12](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/12) so that changes can be deployed without restarting node-red
 -   Automatically creating a new service and replacing the old one if the service type changed
 -   Automatically replacing an accessory with a new one if the accessory information changes (e.g. Name, Manufacturer, ...)
+-   Video Filter value in Camera Control is now optional [#194](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/194) (can be empty, before it was generated if was empty)
+-   Removed updateReachability as it is deprecated (and doesn't make a difference)
 
 ### Added
 

--- a/lib/cameraSource/index.js
+++ b/lib/cameraSource/index.js
@@ -365,13 +365,9 @@ Camera.prototype.handleStreamRequest = function(request) {
                 let audioSsrc = sessionInfo['audio_ssrc']
                 let vf = []
 
-                let videoFilter =
-                    this.videoFilter === ''
-                        ? 'scale=' + width + ':' + height + ''
-                        : this.videoFilter // empty string indicates default
-                // In the case of null, skip entirely
-                if (videoFilter !== null && videoFilter !== 'none') {
-                    vf.push(videoFilter)
+                // Skip vf entirely if videoFilter is empty
+                if (this.videoFilter !== null && this.videoFilter !== '') {
+                    vf.push(this.videoFilter)
 
                     if (this.hflip) vf.push('hflip')
 

--- a/lib/utils/ServiceUtils.js
+++ b/lib/utils/ServiceUtils.js
@@ -115,13 +115,10 @@ module.exports = function(node) {
                 const noResponseMsg = 'NO_RESPONSE'
 
                 if (msg.payload[key] === noResponseMsg) {
-                    node.accessory.updateReachability(false)
                     characteristic.updateValue(new Error(noResponseMsg))
-
+                    
                     return
                 }
-
-                node.accessory.updateReachability(true)
 
                 if (context !== null) {
                     characteristic.setValue(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-homekit-bridged",
-    "version": "1.0.0-dev.8",
+    "version": "1.0.0-dev.9",
     "description": "Node-RED nodes to simulate Apple HomeKit devices.",
     "main": "homekit.js",
     "scripts": {


### PR DESCRIPTION
-   Video Filter value in Camera Control is now optional [#194](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/194) (can be empty, before it was generated if was empty)
-   Removed updateReachability as it is deprecated (and doesn't make a difference)