### PR TITLE
Error status is not passed to callback when "No response" was triggered

### DIFF
--- a/lib/utils/ServiceUtils.js
+++ b/lib/utils/ServiceUtils.js
@@ -7,12 +7,7 @@ module.exports = function(node) {
     const CameraSource = require('../cameraSource').Camera
 
     const onCharacteristicGet = function(callback) {
-        if (node.accessory.reachable === true) {
-            //callback(null, characteristic.value)
-            callback(null, this.value)
-        } else {
-            callback('no response', null)
-        }
+        callback(this.status, this.value)
     }
 
     const onValueChange = function(outputNumber, {oldValue, newValue, context}) {


### PR DESCRIPTION
When we want to trigger "No response" status we call `updateValue` method on characteristic and pass the instance of Error as a value. This error is stored in `status` property. 

Later when HomeKit tries to get the value it calls `getValue` method on characteristic. As we subscribed to `get` event we should pass this stored `state` to `callback` as the first argument in order to see "No response" status in HomeKit.

Here is the flow to reproduce the bug and test the fix in this PR.
```
[{"id":"f29121a.01d3be","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"e83b9af6.b53b7","type":"inject","z":"f29121a.01d3be","name":"20","topic":"","payload":"{\"CurrentTemperature\": 20}","payloadType":"json","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":150,"y":100,"wires":[["b80eaf33.2bd34"]]},{"id":"b80eaf33.2bd34","type":"homekit-service","z":"f29121a.01d3be","isParent":true,"bridge":"cf5c76cc.631598","parentService":"","name":"Temperature","serviceName":"TemperatureSensor","topic":"","filter":false,"manufacturer":"Default Manufacturer","model":"Default Model","serialNo":"Default Serial Number","cameraConfigVideoProcessor":"ffmpeg","cameraConfigSource":"","cameraConfigStillImageSource":"","cameraConfigMaxStreams":2,"cameraConfigMaxWidth":1280,"cameraConfigMaxHeight":720,"cameraConfigMaxFPS":10,"cameraConfigMaxBitrate":300,"cameraConfigVideoCodec":"libx264","cameraConfigAudioCodec":"libfdk_aac","cameraConfigAudio":false,"cameraConfigPacketSize":1316,"cameraConfigVerticalFlip":false,"cameraConfigHorizontalFlip":false,"cameraConfigMapVideo":"0:0","cameraConfigMapAudio":"0:1","cameraConfigVideoFilter":"scale=1280:720","cameraConfigAdditionalCommandLine":"-tune zerolatency","cameraConfigDebug":false,"cameraConfigSnapshotOutput":"disabled","cameraConfigInterfaceName":"","characteristicProperties":"{}","x":430,"y":120,"wires":[[],[]]},{"id":"c324681e.f83418","type":"inject","z":"f29121a.01d3be","name":"25","topic":"","payload":"{\"CurrentTemperature\": 25}","payloadType":"json","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":150,"y":140,"wires":[["b80eaf33.2bd34"]]},{"id":"d8d3b3fb.639ea8","type":"inject","z":"f29121a.01d3be","name":"NO_RESPONSE","topic":"","payload":"{\"CurrentTemperature\": \"NO_RESPONSE\"}","payloadType":"json","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":180,"y":200,"wires":[["b80eaf33.2bd34"]]},{"id":"89d475a6.5a21b8","type":"homekit-service","z":"f29121a.01d3be","isParent":true,"bridge":"cf5c76cc.631598","parentService":"","name":"Light","serviceName":"Lightbulb","topic":"","filter":false,"manufacturer":"Default Manufacturer","model":"Default Model","serialNo":"Default Serial Number","cameraConfigVideoProcessor":"ffmpeg","cameraConfigSource":"","cameraConfigStillImageSource":"","cameraConfigMaxStreams":2,"cameraConfigMaxWidth":1280,"cameraConfigMaxHeight":720,"cameraConfigMaxFPS":10,"cameraConfigMaxBitrate":300,"cameraConfigVideoCodec":"libx264","cameraConfigAudioCodec":"libfdk_aac","cameraConfigAudio":false,"cameraConfigPacketSize":1316,"cameraConfigVerticalFlip":false,"cameraConfigHorizontalFlip":false,"cameraConfigMapVideo":"0:0","cameraConfigMapAudio":"0:1","cameraConfigVideoFilter":"scale=1280:720","cameraConfigAdditionalCommandLine":"-tune zerolatency","cameraConfigDebug":false,"cameraConfigSnapshotOutput":"disabled","cameraConfigInterfaceName":"","characteristicProperties":"{}","x":410,"y":300,"wires":[[],[]]},{"id":"e291ed60.b6da2","type":"inject","z":"f29121a.01d3be","name":"On","topic":"","payload":"{\"On\": 1}","payloadType":"json","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":150,"y":300,"wires":[["89d475a6.5a21b8"]]},{"id":"9e90abd2.0f4288","type":"inject","z":"f29121a.01d3be","name":"On","topic":"","payload":"{\"On\": 0}","payloadType":"json","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":150,"y":340,"wires":[["89d475a6.5a21b8"]]},{"id":"f837739f.60ffe","type":"inject","z":"f29121a.01d3be","name":"NO_RESPONSE","topic":"","payload":"{\"On\": \"NO_RESPONSE\"}","payloadType":"json","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":180,"y":400,"wires":[["89d475a6.5a21b8"]]},{"id":"cf5c76cc.631598","type":"homekit-bridge","z":"","bridgeName":"Test","pinCode":"111-11-111","port":"","allowInsecureRequest":false,"manufacturer":"Default Manufacturer","model":"Default Model","serialNo":"Default Serial Number","customMdnsConfig":false,"mdnsMulticast":true,"mdnsInterface":"","mdnsPort":"","mdnsIp":"","mdnsTtl":"","mdnsLoopback":true,"mdnsReuseAddr":true,"allowMessagePassthrough":false}]
```