### PR TITLE
Removing node.id from accessoryUUID

### DIFF
--- a/lib/HAPServiceNode.js
+++ b/lib/HAPServiceNode.js
@@ -128,7 +128,6 @@ module.exports = function(RED) {
         // changes.
         const accessoryUUID = uuid.generate(
             'A' +
-                node.id +
                 node.name +
                 node.manufacturer +
                 node.serialNo +


### PR DESCRIPTION
Removing node.id from accessoryUUID  to support subflows! (#136)