### PR TITLE
Not using the node.id anymore for *UUIDs (#136)

### DIFF
--- a/lib/HAPServiceNode.js
+++ b/lib/HAPServiceNode.js
@@ -118,7 +118,13 @@ module.exports = function(RED) {
         const bridge = node.bridgeNode.bridge
 
         // Generate UUID from node id
-        const subtypeUUID = uuid.generate(node.id)
+        const subtypeUUID = uuid.generate(
+            'S' +
+                node.name +
+                node.manufacturer +
+                node.serialNo +
+                node.model
+        )
 
         // According to the HomeKit Accessory Protocol Specification the value
         // of the fields Name, Manufacturer, Serial Number and Model must not
@@ -128,7 +134,6 @@ module.exports = function(RED) {
         // changes.
         const accessoryUUID = uuid.generate(
             'A' +
-                node.id +
                 node.name +
                 node.manufacturer +
                 node.serialNo +


### PR DESCRIPTION
Not using the node.id anymore when generates the accessoryUUID and the subTypeUUID.