### PR TITLE
1.2.0-dev.3 Few fixes and new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -   JS console error when opening a linked service [#278](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/278)
 -   Fixed outputs number not being remembered by editor
+-   Fixed saving Software Revision fo Service node
+-   Fixed HAPStorage path on Windows
+
+### Added
+-   Now you can pass Service Name to Subflow Service [#298](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/298)
+-   Added Firmware, Software and Hardware Revision fields to Bridge configuration
+
+### Changed
+-   Now Firmware, Software and Hardware Revision and Model fields are set by default to NRCHKB version, Manufacturer is NRCHKB by default
 
 ## [1.1.1] - 2020.06.30
 

--- a/build/homekit.html
+++ b/build/homekit.html
@@ -32,6 +32,10 @@
             <input type="text" id="node-input-serialNo" placeholder="Serial Number">
         </div>
         <div class="form-row">
+            <label for="node-input-model"><i class="fa fa-wrench"></i> Model</label>
+            <input type="text" id="node-input-model" placeholder="Model">
+        </div>
+        <div class="form-row">
         	<label for="node-input-firmwareRev"><i class="fa fa-wrench"></i> Firmware Revision</label>
         	<input type="text" id="node-input-firmwareRev" placeholder="Firmware Revision">
     	</div>
@@ -40,13 +44,9 @@
         	<input type="text" id="node-input-hardwareRev" placeholder="Hardware Revision">
     	</div>
         <div class="form-row">
-        	<label for="node-input-sofwareRev"><i class="fa fa-wrench"></i> Software Revision</label>
-        	<input type="text" id="node-input-sofwareRev" placeholder="Software Revision">
+        	<label for="node-input-softwareRev"><i class="fa fa-wrench"></i> Software Revision</label>
+        	<input type="text" id="node-input-softwareRev" placeholder="Software Revision">
     	</div>
-        <div class="form-row">
-            <label for="node-input-model"><i class="fa fa-wrench"></i> Model</label>
-            <input type="text" id="node-input-model" placeholder="Model">
-        </div>
     </div>
 
     <div id="isLinked" style="display: none;">
@@ -196,9 +196,9 @@
           <li><strong>Topic</strong>: An optional property that can be configured in the node or, if left blank, can be set by <code>msg.topic</code>. If <em>Filter on Topic</em> is selected <code>msg.topic</code> of incoming messages must match the configured
               value for the message to be accepted. If <em>Filter on Topic</em> is selected and no <em>Topic</em> is set on the node, then <code>msg.topic</code> must match the nodes <em>Name</em></li>
           <li><strong>Manufacturer, Model, Serial Number</strong>: Can be anything you want.</li>
-          <li><strong>Firmware Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>2.9.6</em>. Other types of strings are ignored and won't be displayed.</li>
-          <li><strong>Hardware Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>2.9.6</em>. Other types of strings are ignored and won't be displayed.</li>
-          <li><strong>Software Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>2.9.6</em>. Other types of strings are ignored and won't be displayed.</li>
+          <li><strong>Firmware Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>1.2.0</em>. Other types of strings are ignored and won't be displayed.</li>
+          <li><strong>Hardware Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>1.2.0</em>. Other types of strings are ignored and won't be displayed.</li>
+          <li><strong>Software Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>1.2.0</em>. Other types of strings are ignored and won't be displayed.</li>
           <li><strong>Service</strong>: Choose the type of Service from the list.</li>
           <li><strong>Name</strong>: <em>optional</em></li>
           <li><strong>Camera Configuration</strong>: Additional configuration for CameraControl service.</li>
@@ -287,6 +287,18 @@
         <input type="text" id="node-config-input-model" placeholder="Model">
     </div>
     <div class="form-row">
+        <label for="node-input-firmwareRev"><i class="fa fa-wrench"></i> Firmware Revision</label>
+        <input type="text" id="node-input-firmwareRev" placeholder="Firmware Revision">
+    </div>
+    <div class="form-row">
+        <label for="node-input-hardwareRev"><i class="fa fa-wrench"></i> Hardware Revision</label>
+        <input type="text" id="node-input-hardwareRev" placeholder="Hardware Revision">
+    </div>
+    <div class="form-row">
+        <label for="node-input-softwareRev"><i class="fa fa-wrench"></i> Software Revision</label>
+        <input type="text" id="node-input-softwareRev" placeholder="Software Revision">
+    </div>
+    <div class="form-row">
         <label for="node-config-input-bridgeName"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-config-input-bridgeName" placeholder="Name">
     </div>
@@ -342,6 +354,9 @@
         <li><strong>Port</strong>: If you are behind a Firewall, you may want to specify a port. Otherwise leave empty.</li>
         <li><strong>Allow Insecure Request</strong>: Should we allow insecure request? Default false.</li>
         <li><strong>Manufacturer, Model, Serial Number</strong>: Can be anything you want.</li>
+        <li><strong>Firmware Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>1.2.0</em>. Other types of strings are ignored and won't be displayed.</li>
+        <li><strong>Hardware Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>1.2.0</em>. Other types of strings are ignored and won't be displayed.</li>
+        <li><strong>Software Revision</strong>: Should be a version number string in the form of <em>MAJOR.MINOR.REVISION</em> e.g. <em>1.2.0</em>. Other types of strings are ignored and won't be displayed.</li>
         <li><strong>Name</strong>: If you intend to simulate a rocket, then why don&#39;t you call it <em>Rocket</em>.</li>
         <li><strong>Allow Message Passthrough</strong>: If you allow then message from node input will be send to node output.</li>
         <li><strong>Custom MDNS Configuration</strong>: Check if you would like to use custom mdns configuration.</li>
@@ -371,16 +386,33 @@
 
 <script type="text/javascript">
     let serviceTypes
+    let nrchkbVersion = '0.0.0'
 
     //HomeKitServiceTypes
-    $.getJSON('homekit/service/types', function(data) {
+    $.getJSON('nrchkb/service/types', function(data) {
         serviceTypes = data
     })
+
+    //NRCHKB version
+    $.ajax({
+        url: 'nrchkb/version',
+        dataType: 'json',
+        async: false,
+        success: function(data) {
+            nrchkbVersion = data.version
+            console.log(data)
+        }
+    });
 
     const cameraConfigRequiredField = function(value) {
         if (this.serviceName === 'CameraControl') {
             return (value || '').toString().trim()
         } else return true
+    }
+
+    const versionValidator = (value) => {
+        if (value) return /^(\d+\.)?(\d+\.)?(\.|\d+)$/.test(value)
+        else return true
     }
 
     RED.nodes.registerType('homekit-service', {
@@ -426,11 +458,11 @@
                 value: false,
             },
             manufacturer: {
-                value: 'Default Manufacturer',
+                value: 'NRCHKB',
                 required: true,
             },
             model: {
-                value: 'Default Model',
+                value: nrchkbVersion,
                 required: true,
             },
             serialNo: {
@@ -438,16 +470,19 @@
                 required: true,
             },
             firmwareRev: {
-                value: '1.0.0',
+                value: nrchkbVersion,
                 required: false,
+                validate: versionValidator
             },
             hardwareRev: {
-                value: '1.0.0',
+                value: nrchkbVersion,
                 required: false,
+                validate: versionValidator
             },
             softwareRev: {
-                value: '1.0.0',
+                value: nrchkbVersion,
                 required: false,
+                validate: versionValidator
             },
             cameraConfigVideoProcessor: {
                 value: 'ffmpeg',
@@ -749,16 +784,31 @@
                 required: true,
             },
             manufacturer: {
-                value: 'Default Manufacturer',
+                value: 'NRCHKB',
                 required: true,
             },
             model: {
-                value: 'Default Model',
+                value: nrchkbVersion,
                 required: true,
             },
             serialNo: {
                 value: 'Default Serial Number',
                 required: true,
+            },
+            firmwareRev: {
+                value: nrchkbVersion,
+                required: false,
+                validate: versionValidator
+            },
+            hardwareRev: {
+                value: nrchkbVersion,
+                required: false,
+                validate: versionValidator
+            },
+            softwareRev: {
+                value: nrchkbVersion,
+                required: false,
+                validate: versionValidator
             },
             customMdnsConfig: {
                 value: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-homekit-bridged",
-  "version": "1.2.0-dev.3",
+  "version": "1.2.0-dev.4",
   "description": "Node-RED nodes to simulate Apple HomeKit devices.",
   "main": "build/homekit.js",
   "scripts": {
@@ -48,8 +48,8 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.7",
-    "@types/mocha": "^7.0.2",
-    "@types/node": "^10.17.26",
+    "@types/mocha": "^8.0.0",
+    "@types/node": "^10.17.27",
     "@types/node-red": "^0.20.1",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",
@@ -57,7 +57,7 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "mocha": "^8.0.1",
-    "node-red": "^1.1.1",
+    "node-red": "^1.1.2",
     "node-red-node-test-helper": "^0.2.5",
     "prettier": "^2.0.5",
     "ts-node": "^8.10.2",

--- a/src/homekit.js
+++ b/src/homekit.js
@@ -1,4 +1,5 @@
 module.exports = function(RED) {
+    const path = require('path')
     const debug = require('debug')('NRCHKB')
     const HAPStorage = require('hap-nodejs').HAPStorage
     const API = require('./lib/api')(RED)
@@ -8,7 +9,9 @@ module.exports = function(RED) {
     // Initialize our storage system
     if (RED.settings.available()) {
         debug('RED settings available')
-        HAPStorage.setCustomStoragePath(RED.settings.userDir + '/homekit-persist')
+        const hapStoragePath = path.resolve(RED.settings.userDir, 'homekit-persist')
+        HAPStorage.setCustomStoragePath(hapStoragePath)
+        debug('HAPStorage path set to ', hapStoragePath)
     } else {
         debug('RED settings not available')
     }

--- a/src/lib/HAPBridgeNode.js
+++ b/src/lib/HAPBridgeNode.js
@@ -1,8 +1,8 @@
 module.exports = function(RED) {
-    const debug = require('debug')('NRCHKB')
+    const debug = require('debug')('NRCHKB:HAPBridgeNode')
     const HapNodeJS = require('hap-nodejs')
     const Bridge = HapNodeJS.Bridge
-    const Accessory = HapNodeJS.Accessory
+    const Categories = HapNodeJS.Categories
     const Service = HapNodeJS.Service
     const Characteristic = HapNodeJS.Characteristic
     const uuid = HapNodeJS.uuid
@@ -32,6 +32,9 @@ module.exports = function(RED) {
         this.manufacturer = config.manufacturer
         this.serialNo = config.serialNo
         this.model = config.model
+        this.firmwareRev = config.firmwareRev ? config.firmwareRev : '0.0.0'
+        this.hardwareRev = config.hardwareRev
+        this.softwareRev = config.softwareRev
 
         if (config.customMdnsConfig) {
             this.mdnsConfig = {}
@@ -65,7 +68,7 @@ module.exports = function(RED) {
             }
         }
 
-        this.accessoryType = Accessory.Categories.BRIDGE
+        this.accessoryType = Categories.BRIDGE
         this.published = false
         this.bridgeUsername = macify(this.id)
         const bridgeUUID = uuid.generate(this.id)
@@ -146,12 +149,15 @@ module.exports = function(RED) {
 
             callback()
         })
-
+        
         bridge
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, this.manufacturer)
             .setCharacteristic(Characteristic.SerialNumber, this.serialNo)
             .setCharacteristic(Characteristic.Model, this.model)
+            .setCharacteristic(Characteristic.FirmwareRevision, this.firmwareRev)
+            .setCharacteristic(Characteristic.HardwareRevision, this.hardwareRev)
+            .setCharacteristic(Characteristic.SoftwareRevision, this.softwareRev)
 
         this.bridge = bridge
     }

--- a/src/lib/HAPServiceNode.js
+++ b/src/lib/HAPServiceNode.js
@@ -1,11 +1,19 @@
 module.exports = function(RED) {
-    const debug = require('debug')('NRCHKB')
+    const debug = require('debug')('NRCHKB:HAPServiceNode')
     const HapNodeJS = require('hap-nodejs')
     const uuid = HapNodeJS.uuid
     let publishTimers = {}
 
     const init = function(config) {
         RED.nodes.createNode(this, config)
+        
+        const EnvironmentUtils = require('../lib/utils/EnvironmentUtils')
+        
+        const envName = EnvironmentUtils().evaluateProperty(RED, this, 'name')
+        if (envName) {
+            config.name = envName
+            debug('Overriding name with:', envName)
+        }
 
         this.isParentNode =
             typeof config.isParent === 'boolean' ? config.isParent : true

--- a/src/lib/cameraSource/index.js
+++ b/src/lib/cameraSource/index.js
@@ -7,7 +7,7 @@ const fs = require('fs')
 const ip = require('ip')
 const spawn = require('child_process').spawn
 
-const debug = require('debug')('NRCHKB_Camera')
+const debug = require('debug')('NRCHKB:CameraSource')
 
 module.exports = {
     Camera: Camera,

--- a/src/lib/utils/AccessoryUtils.js
+++ b/src/lib/utils/AccessoryUtils.js
@@ -1,5 +1,5 @@
 module.exports = function(node) {
-    const debug = require('debug')('NRCHKB')
+    const debug = require('debug')('NRCHKB:AccessoryUtils')
     const HapNodeJS = require('hap-nodejs')
     const Accessory = HapNodeJS.Accessory
     const Service = HapNodeJS.Service

--- a/src/lib/utils/BridgeUtils.js
+++ b/src/lib/utils/BridgeUtils.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 module.exports = function(node) {
-    const debug = require('debug')('NRCHKB')
+    const debug = require('debug')('NRCHKB:BridgeUtils')
 
     // Publish accessory after the service has been added
     // BUT ONLY after 5 seconds with no new service have passed

--- a/src/lib/utils/EnvironmentUtils.ts
+++ b/src/lib/utils/EnvironmentUtils.ts
@@ -1,0 +1,13 @@
+import { Red, Node } from 'node-red'
+
+const EnvironmentUtils = () => {
+    const evaluateProperty = (RED: Red, node: Node, propertyName: string) => {
+        return RED.util.evaluateNodeProperty('NRCHKB:' + propertyName, "env", node);
+    }
+
+    return {
+        evaluateProperty: evaluateProperty,
+    }
+}
+
+export = EnvironmentUtils

--- a/src/lib/utils/ServiceUtils.js
+++ b/src/lib/utils/ServiceUtils.js
@@ -1,5 +1,5 @@
 module.exports = function(node) {
-    const debug = require('debug')('NRCHKB')
+    const debug = require('debug')('NRCHKB:ServiceUtils')
     const HapNodeJS = require('hap-nodejs')
     const Service = HapNodeJS.Service
     const Characteristic = HapNodeJS.Characteristic

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -4,6 +4,7 @@ module.exports = function(node) {
     const AccessoryUtils = require('./AccessoryUtils.js')(node)
     const CharacteristicUtils = require('./CharacteristicUtils.js')(node)
     const MdnsUtils = require('./MdnsUtils.js')()
+    const EnvironmentUtils = require('./EnvironmentUtils')()
 
     return {
         ServiceUtils: ServiceUtils,
@@ -11,5 +12,6 @@ module.exports = function(node) {
         AccessoryUtils: AccessoryUtils,
         CharacteristicUtils: CharacteristicUtils,
         MdnsUtils: MdnsUtils,
+        EnvironmentUtils: EnvironmentUtils
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2020",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2020.string"],                             /* Specify library files to be included in the compilation. */
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     "checkJs": false,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
@@ -61,7 +61,8 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/test/*", "build"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,40 +3,40 @@
 
 
 "@babel/code-frame@^7.0.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
-  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   dependencies:
-    "@babel/highlight" "^7.8.3"
+    "@babel/highlight" "^7.10.4"
 
-"@babel/helper-validator-identifier@^7.9.0":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
-  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
-"@babel/highlight@^7.8.3":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
-  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.9.0"
+    "@babel/helper-validator-identifier" "^7.10.4"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
 "@babel/runtime@^7.3.1":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
-  integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
+  integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@node-red/editor-api@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@node-red/editor-api/-/editor-api-1.1.1.tgz#892dcb603d4eeb7d73023972dc0912b5180a10a4"
-  integrity sha512-dTZvojeSh2i2Ehpf6TSsTSsIov+uB+Syt3Dc+y1BSkW8sFwd4qj4hVVGalBDPX0NdL5wlX6GcmIpvGNYHaY6Rw==
+"@node-red/editor-api@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@node-red/editor-api/-/editor-api-1.1.2.tgz#2fc234f289de0fe2e55a8903d2a4ec7e4e0d42df"
+  integrity sha512-yvA7sO9kqpnojwtnO+K03CsRfU9XBIVYTnPHJYcA94IhxF/sm+iCL1VlZPEMXTEt4VvMfTRKY9U1bHIVAKBtLA==
   dependencies:
-    "@node-red/editor-client" "1.1.1"
-    "@node-red/util" "1.1.1"
+    "@node-red/editor-client" "1.1.2"
+    "@node-red/util" "1.1.2"
     bcryptjs "2.4.3"
     body-parser "1.19.0"
     clone "2.1.2"
@@ -55,15 +55,15 @@
   optionalDependencies:
     bcrypt "3.0.6"
 
-"@node-red/editor-client@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@node-red/editor-client/-/editor-client-1.1.1.tgz#204abf6ce6651084e51588c4ed2251eb7d712bb4"
-  integrity sha512-fwraNAegth1EpqsusbctqKx3dkjRg8vs5S3tQnyILQ9HSi19IwoXE5kWrs+g64QI9yyDKcoEfsG+82BQ2UFpXA==
+"@node-red/editor-client@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@node-red/editor-client/-/editor-client-1.1.2.tgz#249d0a8b20a45c8f89eadd12912870064f0be019"
+  integrity sha512-cHsRxs/0QWqSO8LtTlwIsbEdTADjy3N5KOB2V1E3pNhz4zPy3+6472bnDF93HmywRen1wOWVXxBQTAf5aOHfaQ==
 
-"@node-red/nodes@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@node-red/nodes/-/nodes-1.1.1.tgz#e28d0305e040e30cbe90d9cd7819c038c721ff95"
-  integrity sha512-WpjRmpWbNSWGGrU78MI3FykkiSgtPLTOIA4UCOFShlOQ6feeaMDdkBOKUyTt2YWniP29DpPMB3dG7z11iafI2Q==
+"@node-red/nodes@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@node-red/nodes/-/nodes-1.1.2.tgz#d0dd288224d08406594ed0cb3ffa389975f379da"
+  integrity sha512-sVwwrkCpT/padCcPMIQH4Yro4+qOYBBCkn85FnTY+7KlGLUPLhFQr4A30mWoJX5Wk+zTpe3nXqr9R0ccGrhWYg==
   dependencies:
     ajv "6.12.3"
     body-parser "1.19.0"
@@ -91,33 +91,33 @@
     ws "6.2.1"
     xml2js "0.4.23"
 
-"@node-red/registry@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@node-red/registry/-/registry-1.1.1.tgz#6b49e2cd72c1ebe8d1177bab2a1a41198adf07d1"
-  integrity sha512-KXfnlm+0Rhwyu1E18osv1ZNm6ehAS89rCeDDT/wDZEmsLJIqZm4m9s5HsDlH+OLAGv0FxKcUbPOv0vHwPnSKJw==
+"@node-red/registry@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@node-red/registry/-/registry-1.1.2.tgz#dc4686b8b0719c8f884bf158822c9671a604ff62"
+  integrity sha512-ApbQviP0q77zI1BREFhbMbNzP972RB4BtZHUOFbXGbcSLaQpX7QLt7+gNTkwTEg5VwHt1nQPNWbAVdP+Aq3RiA==
   dependencies:
-    "@node-red/util" "1.1.1"
+    "@node-red/util" "1.1.2"
     semver "6.3.0"
     uglify-js "3.10.0"
     when "3.7.8"
 
-"@node-red/runtime@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@node-red/runtime/-/runtime-1.1.1.tgz#b9b757e9a5e4a3385752a94e0ac1e71d7cddb0cf"
-  integrity sha512-5HQpER2ibc8bM14cNIsykUcUKs0QbsJRjufam5/5R6Z7A+FdJz6cu6hMkcHxyCz+4nOUv33nY8/NSpltJ5thYA==
+"@node-red/runtime@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@node-red/runtime/-/runtime-1.1.2.tgz#870f7b9e590f2cc75fbefadfe3ccd8c180088cb3"
+  integrity sha512-szt7L6/wWZax84VsgER8uZB3rnBHofjb2b1qQzRm4yG02O8YZ8elw1kKi0b6B6D+Xo5h3z29h/oJyYdBS8/9sA==
   dependencies:
-    "@node-red/registry" "1.1.1"
-    "@node-red/util" "1.1.1"
+    "@node-red/registry" "1.1.2"
+    "@node-red/util" "1.1.2"
     clone "2.1.2"
     express "4.17.1"
     fs-extra "8.1.0"
     json-stringify-safe "5.0.1"
     when "3.7.8"
 
-"@node-red/util@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@node-red/util/-/util-1.1.1.tgz#1aec5e8f8f85bd28ce29784fce03de3d9998b6db"
-  integrity sha512-rJeTA4KcQoAeQnfF05sC7tX3HKak+cUNE0eeORSe3tefYUE931QApBw8bjneOoS12gBQZGQJHWYhwrhT8+jzqA==
+"@node-red/util@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@node-red/util/-/util-1.1.2.tgz#d5edadf13364a6b5c9c84b8a06bfc119ec3ed992"
+  integrity sha512-9G45g4W7HcCJ9IpIF76sCbDuqHWHmkAHI+lNE02TC8yvGzEOyb6VMvU0vph5JT499752WSlNQwk/g823VrqYLw==
   dependencies:
     clone "2.1.2"
     i18next "15.1.2"
@@ -189,9 +189,9 @@
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
 "@types/express-serve-static-core@*":
-  version "4.17.7"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz#dfe61f870eb549dc6d7e12050901847c7d7e915b"
-  integrity sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==
+  version "4.17.8"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz#b8f7b714138536742da222839892e203df569d1c"
+  integrity sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -212,10 +212,10 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.2.tgz#857a118d8634c84bba7ae14088e4508490cd5da5"
   integrity sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==
 
-"@types/mocha@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
-  integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
+"@types/mocha@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.0.0.tgz#b0ba1c5b4cb3880c51a6b488ad007a657d1be888"
+  integrity sha512-jWeYcTo3sCH/rMgsdYXDTO85GNRyTCII5dayMIu/ZO4zbEot1E3iNGaOwpLReLUHjeNQFkgeNNVYlY4dX6azQQ==
 
 "@types/node-red@^0.20.1":
   version "0.20.1"
@@ -225,14 +225,14 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "14.0.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.5.tgz#3d03acd3b3414cf67faf999aed11682ed121f22b"
-  integrity sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==
+  version "14.0.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.22.tgz#23ea4d88189cec7d58f9e6b66f786b215eb61bdc"
+  integrity sha512-emeGcJvdiZ4Z3ohbmw93E/64jRzUHAItSHt8nF7M4TGgQTiWqFVGB8KNpLGFmUHmHLvjvBgFwVlqNcq+VuGv9g==
 
-"@types/node@^10.17.26":
-  version "10.17.26"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.26.tgz#a8a119960bff16b823be4c617da028570779bcfd"
-  integrity sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw==
+"@types/node@^10.17.27":
+  version "10.17.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.27.tgz#391cb391c75646c8ad2a7b6ed3bbcee52d1bdf19"
+  integrity sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -286,9 +286,9 @@ acorn@^7.2.0:
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 agent-base@6:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.0.tgz#5d0101f19bbfaed39980b22ae866de153b93f09a"
-  integrity sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
   dependencies:
     debug "4"
 
@@ -300,7 +300,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@6.12.3:
+ajv@6.12.3, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
@@ -310,25 +310,10 @@ ajv@6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
-  version "6.12.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
-  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ansi-colors@4.1.1:
+ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-
-ansi-colors@^3.2.1:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
-  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-escapes@^4.3.0:
   version "4.3.1"
@@ -537,9 +522,9 @@ bcryptjs@2.4.3, bcryptjs@^2.4.3:
   integrity sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=
 
 binary-extensions@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
-  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
+  integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
 bl@^1.2.1:
   version "1.2.2"
@@ -566,9 +551,9 @@ body-parser@1.19.0:
     type-is "~1.6.17"
 
 bonjour-hap@~3.5.10:
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/bonjour-hap/-/bonjour-hap-3.5.10.tgz#a9cd35dabf8eb75e9bfc54871d19d0c4ee41ed4e"
-  integrity sha512-vaqa4uUST8K5rj9QGe6GaSJ+6rQ24KzgkjdyZvoTpbKBti5xL/m8H9Dp9VmPdo434OAetqU5PKAn5izucrKEBA==
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/bonjour-hap/-/bonjour-hap-3.5.11.tgz#318db8d0169cc20a77e769075749f9ac87f807c1"
+  integrity sha512-pSYWWxjx3t2vh3sMkBMxQ0QaCqFgqWFz9he9U1JSQ6Lvwev5W19J+nBQWFj55dzUOcH0rPtZh/A+k/MvI5etQw==
   dependencies:
     array-flatten "^2.1.2"
     deep-equal "^2.0.2"
@@ -652,9 +637,9 @@ chalk@^2.0.0, chalk@^2.4.2:
     supports-color "^5.3.0"
 
 chalk@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
-  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -1179,11 +1164,11 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
     once "^1.4.0"
 
 enquirer@^2.3.5:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.5.tgz#3ab2b838df0a9d8ab9e7dff235b0e8712ef92381"
-  integrity sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
-    ansi-colors "^3.2.1"
+    ansi-colors "^4.1.1"
 
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
@@ -1191,9 +1176,9 @@ entities@^1.1.1, entities@~1.1.1:
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 entities@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.2.tgz#ac74db0bba8d33808bbf36809c3a5c3683531436"
-  integrity sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1203,21 +1188,21 @@ error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstract@^1.17.5:
-  version "1.17.5"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
-  integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
+  version "1.17.6"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
+  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
   dependencies:
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
-    is-callable "^1.1.5"
-    is-regex "^1.0.5"
+    is-callable "^1.2.0"
+    is-regex "^1.1.0"
     object-inspect "^1.7.0"
     object-keys "^1.1.1"
     object.assign "^4.1.0"
-    string.prototype.trimleft "^2.1.1"
-    string.prototype.trimright "^2.1.1"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
 
 es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
@@ -1336,18 +1321,13 @@ eslint-scope@^5.1.0:
     estraverse "^4.1.1"
 
 eslint-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
-  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
-  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
-
-eslint-visitor-keys@^1.2.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -1451,9 +1431,9 @@ event-emitter@~0.3.5:
     es5-ext "~0.10.14"
 
 execa@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.2.tgz#ad87fb7b2d9d564f70d2b62d511bee41d5cbb240"
-  integrity sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.3.tgz#0a34dabbad6d66100bd6f2c576c8669403f317f2"
+  integrity sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==
   dependencies:
     cross-spawn "^7.0.0"
     get-stream "^5.0.0"
@@ -1538,9 +1518,9 @@ extsprintf@^1.2.0:
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
   version "1.2.0"
@@ -2116,10 +2096,10 @@ is-buffer@~2.0.3:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.4, is-callable@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
-  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+is-callable@^1.1.4, is-callable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
+  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
 is-date-object@^1.0.1, is-date-object@^1.0.2:
   version "1.0.2"
@@ -2187,12 +2167,12 @@ is-obj@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
-is-regex@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
-  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
+is-regex@^1.0.5, is-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
+  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
   dependencies:
-    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 is-regexp@^1.0.0:
   version "1.0.0"
@@ -2426,9 +2406,9 @@ lint-staged@^10.2.11:
     stringify-object "^3.3.0"
 
 listr2@^2.1.0:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.1.8.tgz#8af7ebc70cdbe866ddbb6c80909142bd45758f1f"
-  integrity sha512-Op+hheiChfAphkJ5qUxZtHgyjlX9iNnAeFS/S134xw7mVSg0YVrQo1IY4/K+ElY6XgOPg2Ij4z07urUXR+YEew==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.2.0.tgz#cb88631258abc578c7fb64e590fe5742f28e4aac"
+  integrity sha512-Q8qbd7rgmEwDo1nSyHaWQeztfGsdL6rb4uh7BA+Q80AZiDET5rVntiU1+13mu2ZTDVaBVbvAD1Db11rnu3l9sg==
   dependencies:
     chalk "^4.0.0"
     cli-truncate "^2.1.0"
@@ -2525,9 +2505,9 @@ lodash.some@^4.4.0:
   integrity sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=
 
 lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@3.0.0:
   version "3.0.0"
@@ -2707,9 +2687,9 @@ moment-timezone@^0.5.31, moment-timezone@^0.5.x:
     moment ">= 2.9.0"
 
 "moment@>= 2.9.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
-  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
 
 mqtt-packet@^5.6.0:
   version "5.6.1"
@@ -2828,9 +2808,9 @@ next-tick@~1.0.0:
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nise@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.3.tgz#9f79ff02fa002ed5ffbc538ad58518fa011dc913"
-  integrity sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
     "@sinonjs/fake-timers" "^6.0.0"
@@ -2918,15 +2898,15 @@ node-red-node-test-helper@^0.2.5:
     stoppable "1.1.0"
     supertest "4.0.2"
 
-node-red@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/node-red/-/node-red-1.1.1.tgz#22fed461c83d66637128cf8fbf24bedb633886c7"
-  integrity sha512-+EC92zplIqo7ljpg+SDvSkPVmQyz2m1Tot7aj8hE2+ixX5P206K5VRmxbkz2UXxOem7ZkWZ95/JCGelceZ8MMQ==
+node-red@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/node-red/-/node-red-1.1.2.tgz#8a1214b023bdeb67c84221577ef024384e2e4f93"
+  integrity sha512-In2GzDLER2Bm5SkuEQVrekrSFtPljpkMaEYcZxNkbTomYixI63PrCm1IJEZjEBjSkFaK5zY1t3sfEHKdAla+MQ==
   dependencies:
-    "@node-red/editor-api" "1.1.1"
-    "@node-red/nodes" "1.1.1"
-    "@node-red/runtime" "1.1.1"
-    "@node-red/util" "1.1.1"
+    "@node-red/editor-api" "1.1.2"
+    "@node-red/nodes" "1.1.2"
+    "@node-red/runtime" "1.1.2"
+    "@node-red/util" "1.1.2"
     basic-auth "2.0.1"
     bcryptjs "2.4.3"
     express "4.17.1"
@@ -3032,9 +3012,9 @@ object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-inspect@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
-  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
+  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
 object-is@^1.1.2:
   version "1.1.2"
@@ -3086,9 +3066,9 @@ onetime@^5.1.0:
     mimic-fn "^2.1.0"
 
 opencollective-postinstall@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
-  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
+  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -3605,9 +3585,9 @@ rimraf@^2.6.1:
     glob "^7.1.3"
 
 rxjs@^6.5.5:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
-  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
+  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
   dependencies:
     tslib "^1.9.0"
 
@@ -3950,7 +3930,7 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.trimend@^1.0.0:
+string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
   integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
@@ -3958,25 +3938,7 @@ string.prototype.trimend@^1.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
-string.prototype.trimleft@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
-  integrity sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimstart "^1.0.0"
-
-string.prototype.trimright@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz#c76f1cef30f21bbad8afeb8db1511496cfb0f2a3"
-  integrity sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimend "^1.0.0"
-
-string.prototype.trimstart@^1.0.0:
+string.prototype.trimstart@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
   integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
@@ -4051,9 +4013,9 @@ strip-json-comments@3.0.1:
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
 strip-json-comments@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
-  integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -4109,9 +4071,9 @@ table@^5.2.3:
     string-width "^3.0.0"
 
 tail@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tail/-/tail-2.0.3.tgz#37567adc4624a70b35f1d146c3376fa3d6ef7c04"
-  integrity sha512-s9NOGkLqqiDEtBttQZI7acLS8ycYK5sTlDwNjGnpXG9c8AWj0cfAtwEIzo/hVRMMiC5EYz+bXaJWC1u1u0GPpQ==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/tail/-/tail-2.0.4.tgz#4824de583004df17606d04854aa3cc3491b17010"
+  integrity sha512-xHkZdNWIzO++g+V/rHGqVoHd2LRxz+8t8bj6FGelfb8FHBjg5yjkX7Su/8sQSBo5alIspYkRp/fU0A2SM5h+5A==
 
 tar@^4, tar@^4.4.2:
   version "4.4.13"
@@ -4341,9 +4303,9 @@ uuid@^3.3.2:
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-compile-cache@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
-  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
+  integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
### Fixed
-   Fixed saving Software Revision fo Service node
-   Fixed HAPStorage path on Windows

### Added
-   Now you can pass Service Name to Subflow Service [#298](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/298)
-   Added Firmware, Software and Hardware Revision fields to Bridge configuration

### Changed
-   Now Firmware, Software and Hardware Revision and Model fields are set by default to NRCHKB version, Manufacturer is NRCHKB by default