### PR TITLE
Wait parent node initiation before accessing it

### DIFF
--- a/src/lib/HAPServiceNode.ts
+++ b/src/lib/HAPServiceNode.ts
@@ -91,6 +91,7 @@ module.exports = (RED: NodeAPI) => {
         if (self.config.isParent) {
             debug('Starting Parent Service ' + config.name)
             configure.call(self)
+            self.configured = true
         } else {
             ServiceUtils.waitForParent()
                 .then(() => {
@@ -103,6 +104,7 @@ module.exports = (RED: NodeAPI) => {
                             config.name
                     )
                     configure.call(self)
+                    self.configured = true
                 })
                 .catch((error: any) => {
                     UnifiedLogger.error(

--- a/src/lib/types/HAPServiceNodeType.ts
+++ b/src/lib/types/HAPServiceNodeType.ts
@@ -8,6 +8,7 @@ type HAPServiceNodeType = Node & {
     config: HAPServiceConfigType
     RED: NodeAPI
     setupDone: boolean
+    configured: boolean
     handleWaitForSetup: (msg: any) => any
     onIdentify: (paired: boolean, callback: () => any) => void
     hostNode: HAPHostNodeType

--- a/src/lib/utils/ServiceUtils.js
+++ b/src/lib/utils/ServiceUtils.js
@@ -303,7 +303,8 @@ module.exports = function (node) {
             })
 
             const checkAndWait = () => {
-                if (node.RED.nodes.getNode(node.config.parentService)) {
+                const parentNode = node.RED.nodes.getNode(node.config.parentService)
+                if (parentNode && parentNode.configured) {
                     resolve()
                 } else {
                     setTimeout(checkAndWait, 1000)


### PR DESCRIPTION
There is an issue: the linked service throws error during setup if parent waits for the setup message
Changed the behaviour of the [ServiceUtils.waitForParent](https://github.com/NRCHKB/node-red-contrib-homekit-bridged/blob/0a4b71252e794f4a1c7774b335eb096bf6f0f894/src/lib/utils/ServiceUtils.js#L307) function to wait parent to be configured