### PR TITLE
Fix Discord notifiction for dev workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NODE_TKN}}
       - name: Discord notification
+        if: contains(env.PACKAGE_VERSION, 'dev') == true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_DEV_ANN }}
           DISCORD_EMBEDS: toJSON("{"embed":{"title":"New dev version `${{ env.PACKAGE_VERSION }}` has been released.","description":"Changelog available [here](https:\/\/github.com\/NRCHKB\/node-red-contrib-homekit-bridged\/commits\/dev\/CHANGELOG.md)","url":"https:\/\/github.com\/NRCHKB\/node-red-contrib-homekit-bridged\/tree\/dev","color":9371648,"fields":[{"name":"How to install","value":"1. Stop node-red\n2. Backup `~\/.node-red` folder\n3. `cd ~\/.node-red`\n4. `npm i node-red-contrib-homekit-bridged@${{ env.PACKAGE_VERSION }}`\n5. Start node-red"}]}}")


### PR DESCRIPTION
Looks like even if publish is skipped then discord is notified about new release.

## Is
### Wrong
1. package.json version is 1.3.0
2. There is no npmjs.com publish due to rule `contains(env.PACKAGE_VERSION, 'dev') == true`
3. Discord is notified, but there is no new dev release

### Correct
1. package.json version is 1.3.0-dev.0
2. There is npmjs.com publish due to rule `contains(env.PACKAGE_VERSION, 'dev') == true`
3. Discord is notified as there is a new release

## Should be:
### Correct
1. package.json version is 1.3.0
2. There is no npmjs.com publish due to rule `contains(env.PACKAGE_VERSION, 'dev') == true`
3. Discord is **NOT** notified as there is no new dev release

### Correct
1. package.json version is 1.3.0-dev.0
2. There is npmjs.com publish due to rule `contains(env.PACKAGE_VERSION, 'dev') == true`
3. Discord is notified as there is a new release