### PR TITLE
Persistent accessory identifier for subflows

### DIFF
--- a/src/lib/HAPServiceNode.ts
+++ b/src/lib/HAPServiceNode.ts
@@ -167,7 +167,6 @@ module.exports = (RED: NodeAPI) => {
         self.name = self.config.name
 
         // Find a unique identifier for the current service
-        let uniqueIdentifier
         if(
             self.hasOwnProperty('_flow') && 
             self.hasOwnProperty('_alias') && 
@@ -176,14 +175,14 @@ module.exports = (RED: NodeAPI) => {
         ) {
             // For subflows, use the service node identifier from the subflow template 
             // plus the full path from the subflow node identifier to the subflow.
-            uniqueIdentifier = self._alias + '/' + self._flow.path
+            self.uniqueIdentifier = self._alias + '/' + self._flow.path
         } else {
             // For top level flows, use the node identifier
-            uniqueIdentifier = self.id
+            self.uniqueIdentifier = self.id
         }
 
-        // Generate UUID from node id
-        const subtypeUUID = uuid.generate(uniqueIdentifier)
+        // Generate UUID from unique identifier
+        const subtypeUUID = uuid.generate(self.uniqueIdentifier)
 
         // Look for existing Accessory or create a new one
         if (self.config.hostType == HostType.BRIDGE) {
@@ -196,7 +195,7 @@ module.exports = (RED: NodeAPI) => {
                 // changes.
                 const accessoryUUID = uuid.generate(
                     'A' +
-                        uniqueIdentifier +
+                        self.uniqueIdentifier +
                         self.name +
                         self.config.manufacturer +
                         self.config.serialNo +

--- a/src/lib/types/FlowType.ts
+++ b/src/lib/types/FlowType.ts
@@ -1,0 +1,11 @@
+enum FlowTypeType {
+    Subflow = 'subflow',
+    Flow = 'flow'
+}
+
+type FlowType = {
+    TYPE: FlowTypeType
+    path: string
+}
+
+export { FlowType, FlowTypeType }

--- a/src/lib/types/HAPHostNodeType.ts
+++ b/src/lib/types/HAPHostNodeType.ts
@@ -1,10 +1,10 @@
-import { Node } from 'node-red'
+import NodeType from './NodeType'
 import HAPHostConfigType from './HAPHostConfigType'
 import { Accessory, Categories } from 'hap-nodejs'
 import HostType from './HostType'
 import { MulticastOptions } from 'bonjour-hap'
 
-type HAPHostNodeType = Node & {
+type HAPHostNodeType = NodeType & {
     config: HAPHostConfigType
     mdnsConfig: MulticastOptions
     accessoryCategory: Categories

--- a/src/lib/types/HAPServiceNodeType.ts
+++ b/src/lib/types/HAPServiceNodeType.ts
@@ -3,6 +3,7 @@ import HAPServiceConfigType from './HAPServiceConfigType'
 import { Accessory, CharacteristicProps, Service } from 'hap-nodejs'
 import HAPHostNodeType from './HAPHostNodeType'
 import PublishTimersType from './PublishTimersType'
+import { FlowType } from './FlowType'
 
 type HAPServiceNodeType = Node & {
     config: HAPServiceConfigType
@@ -23,6 +24,8 @@ type HAPServiceNodeType = Node & {
     onCharacteristicGet: any
     onCharacteristicSet: any
     onCharacteristicChange: any
+    _flow: FlowType
+    _alias: string
 }
 
 export default HAPServiceNodeType

--- a/src/lib/types/HAPServiceNodeType.ts
+++ b/src/lib/types/HAPServiceNodeType.ts
@@ -1,11 +1,11 @@
-import { Node, NodeAPI } from 'node-red'
+import NodeType from './NodeType'
+import { NodeAPI } from 'node-red'
 import HAPServiceConfigType from './HAPServiceConfigType'
 import { Accessory, CharacteristicProps, Service } from 'hap-nodejs'
 import HAPHostNodeType from './HAPHostNodeType'
 import PublishTimersType from './PublishTimersType'
-import { FlowType } from './FlowType'
 
-type HAPServiceNodeType = Node & {
+type HAPServiceNodeType = NodeType & {
     config: HAPServiceConfigType
     RED: NodeAPI
     setupDone: boolean
@@ -24,8 +24,7 @@ type HAPServiceNodeType = Node & {
     onCharacteristicGet: any
     onCharacteristicSet: any
     onCharacteristicChange: any
-    _flow: FlowType
-    _alias: string
+    uniqueIdentifier: string
 }
 
 export default HAPServiceNodeType

--- a/src/lib/types/NodeType.ts
+++ b/src/lib/types/NodeType.ts
@@ -1,0 +1,9 @@
+import { Node } from 'node-red'
+import { FlowType } from './FlowType'
+
+type NodeType = Node & {
+    _flow: FlowType
+    _alias: string
+}
+
+export default NodeType


### PR DESCRIPTION
As outlined in #393, this pull request fixes the issue of changing identifiers in subflows. This is a non-breaking change, as identifiers for top level flows remain persistent. All existing nrchkb service nodes in subflows will create a new uuid for a last time and remain persistent afterwards.

It also resolves #298.

I also request to reject #236 as this pull request fixes the subflow issues without a breaking change and forcing users to use distinct serial numbers.