### PR TITLE
Warn about unexpected behaviour of new Bridge in a Subflow #393

### DIFF
--- a/build/nodes/nrchkb.html
+++ b/build/nodes/nrchkb.html
@@ -1,3 +1,19 @@
+<style>
+    .alert {
+        position: relative;
+        padding: .75rem 1.25rem;
+        margin-bottom: 1rem;
+        border: 1px solid transparent;
+        border-radius: .25rem;
+        margin-right: 60px;
+    }
+    .alert-warning {
+        color: #856404;
+        background-color: #fff3cd;
+        border-color: #ffeeba;
+    }
+</style>
+
 <script type="text/javascript">
     const initExperimental = function () {
         //NRCHKB Custom Characteristics

--- a/build/nodes/service.html
+++ b/build/nodes/service.html
@@ -26,6 +26,9 @@
             </select>
         </div>
         <div id="isOnBridge">
+            <div id="isBridgeInSubflow" class="alert alert-warning" role="alert">
+              Read more <b><a href="#" id="bridgeInSubflowNotice">here</a></b> about adding Bridge in a Subflow.
+            </div>
             <div class="form-row" style="height: 34px;">
                 <label for="node-input-bridge">
               <i class="fa fa-rocket"></i>
@@ -534,13 +537,23 @@
             }
 
             let isOnBridgeDiv = $('#isOnBridge')
+            let isBridgeInSubflow = $('#isBridgeInSubflow')
             let isAccessoryDiv = $('#isAccessory')
+
+            const inSubflow = !!RED.nodes.subflow(node.z)
 
             selectHostType
                 .change(function () {
                     if (selectHostType.val() == 0) {
                         isAccessoryDiv.hide()
                         isOnBridgeDiv.show()
+
+                        if (inSubflow) {
+                            isBridgeInSubflow.show()
+                        } else {
+                            isBridgeInSubflow.hide()
+                        }
+
                         $("#node-input-accessoryId").val("_ADD_");
                     } else {
                         isOnBridgeDiv.hide()
@@ -594,8 +607,6 @@
             })
 
             const selectParentService = $('#node-input-parentService')
-
-            const inSubflow = !!RED.nodes.subflow(node.z)
 
             const candidateNodes = RED.nodes.filterNodes({
                 type: 'homekit-service',
@@ -671,6 +682,30 @@
                     accessoryOption.attr("disabled", true);
                     accessoryOption.text(accessoryOption.text() + " already used by " + n.name)
                 }
+            })
+
+            isBridgeInSubflow.find('#bridgeInSubflowNotice').on("click", function () {
+                $('<div>')
+                    .css({maxHeight: '80%'})
+                    .html("<ul>" +
+                        "<li>If a Bridge is created within the Flow, then each Service node in a Subflow will be added to the existing (single) Bridge.</li>" +
+                        "<li>If a Bridge is created within the Subflow, a new Bridge will be created for each Subflow instance.</li>" +
+                        "<li>If a Standalone Accessory is being used, it is recommended to set it up completly within the Subflow editor. This will add a new Standalone Accessory for each Subflow instance in your Flow.</li>" +
+                        "<li>Visit our <b><a href=\"https://nrchkb.github.io/wiki/introduction/service-node/#bridge\">wiki</a></b> for more informations.</li>" +
+                        "</ul>")
+                    .dialog({
+                        draggable: true,
+                        modal: true,
+                        resizable: false,
+                        width: 'auto',
+                        title: 'Important Notice',
+                        minHeight: 75,
+                        buttons: {
+                            Close: function () {
+                                $(this).dialog('destroy')
+                            }
+                        }
+                    })
             })
         },
         oneditsave: function () {

--- a/src/lib/HAPHostNode.ts
+++ b/src/lib/HAPHostNode.ts
@@ -71,9 +71,9 @@ module.exports = (RED: NodeAPI, hostType: HostType) => {
             }
         }
 
-        self.accessoryCategory = ((self.hostType == HostType.BRIDGE
+        self.accessoryCategory = (self.hostType == HostType.BRIDGE
             ? HapCategories.BRIDGE
-            : self.config.accessoryCategory) as unknown) as Categories
+            : self.config.accessoryCategory) as unknown as Categories
 
         self.published = false
         self.bridgeUsername = macify(self.id)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -324,7 +324,7 @@ module.exports = function (RED: NodeAPI) {
             .sort()
             .filter((x) => parseInt(x) >= 0)
             .forEach((key) => {
-                const keyNumber = (key as unknown) as number
+                const keyNumber = key as unknown as number
                 accessoryCategoriesData[keyNumber] = HapCategories[keyNumber]
             })
 

--- a/src/test/lib/HAPBridgeNode.test.ts
+++ b/src/test/lib/HAPBridgeNode.test.ts
@@ -14,7 +14,7 @@ describe('HAPHostNode', function () {
     })
 
     it('null string macify should fail', function (done) {
-        const stringToMacify = (null as unknown) as string
+        const stringToMacify = null as unknown as string
         should.throws(() => {
             HAPHostNode.macify(stringToMacify)
         }, 'nodeId cannot be empty in macify process')
@@ -22,7 +22,7 @@ describe('HAPHostNode', function () {
     })
 
     it('undefined string macify should fail', function (done) {
-        const stringToMacify = (undefined as unknown) as string
+        const stringToMacify = undefined as unknown as string
         should.throws(() => {
             HAPHostNode.macify(stringToMacify)
         }, 'nodeId cannot be empty in macify process')


### PR DESCRIPTION
When you create a new Bridge for Service Node that is in a subflow, once deployed new Bridge will be created for each Subflow instance in a flow. If you create a Bridge outside a Subflow then it will be created only once (reused).

This PR adds warning message for Service in a Subflow when user tries to set up Bridge

![image](https://user-images.githubusercontent.com/2881159/117374136-e4caf600-aecc-11eb-8077-47b33d2e0d1a.png)

Warning links to https://nrchkb.github.io/wiki/introduction/service-node/#bridge