### PR TITLE
Fix default values for adaptive lighting mode

### DIFF
--- a/build/nodes/service.html
+++ b/build/nodes/service.html
@@ -499,11 +499,11 @@
             },
             adaptiveLightingOptionsMode: {
                 value: 1,
-                validate: RED.validators.number()
+                validate: RED.validators.number(true)
             },
             adaptiveLightingOptionsCustomTemperatureAdjustment: {
                 value: 0,
-                validate: RED.validators.number()
+                validate: RED.validators.number(true)
             },
         },
         inputs: 1,
@@ -612,6 +612,17 @@
 
             let cameraConfiguration = $('#camera-configuration')
             let adaptiveLightningConfiguration = $('#adaptive-lightning-configuration')
+
+            const adaptiveLightingOptionsMode = $("#node-input-adaptiveLightingOptionsMode")
+            const adaptiveLightingOptionsCustomTemperatureAdjustment = $("#node-input-adaptiveLightingOptionsCustomTemperatureAdjustment")
+
+            // Need to handle existing node - add missing default values
+            if (node.adaptiveLightingOptionsMode === undefined) {
+                adaptiveLightingOptionsMode.val("1");
+            }
+            if (node.adaptiveLightingOptionsCustomTemperatureAdjustment === undefined) {
+                adaptiveLightingOptionsCustomTemperatureAdjustment.val("0");
+            }
 
             selectServiceName
                 .find('option')

--- a/build/nodes/service2.html
+++ b/build/nodes/service2.html
@@ -509,11 +509,11 @@ if (nrchkbExperimental) {
             },
             adaptiveLightingOptionsMode: {
                 value: 1,
-                validate: RED.validators.number()
+                validate: RED.validators.number(true)
             },
             adaptiveLightingOptionsCustomTemperatureAdjustment: {
                 value: 0,
-                validate: RED.validators.number()
+                validate: RED.validators.number(true)
             },
         },
         inputs: 1,
@@ -614,6 +614,17 @@ if (nrchkbExperimental) {
 
             let cameraConfiguration = $('#camera-configuration')
             let adaptiveLightningConfiguration = $('#adaptive-lightning-configuration')
+
+            const adaptiveLightingOptionsMode = $("#node-input-adaptiveLightingOptionsMode")
+            const adaptiveLightingOptionsCustomTemperatureAdjustment = $("#node-input-adaptiveLightingOptionsCustomTemperatureAdjustment")
+
+            // Need to handle existing node - add missing default values
+            if (node.adaptiveLightingOptionsMode === undefined) {
+                adaptiveLightingOptionsMode.val("1");
+            }
+            if (node.adaptiveLightingOptionsCustomTemperatureAdjustment === undefined) {
+                adaptiveLightingOptionsCustomTemperatureAdjustment.val("0");
+            }
 
             selectServiceName
                 .find('option')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-red-contrib-homekit-bridged",
-    "version": "1.7.0-dev.4",
+    "version": "1.7.0-dev.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "node-red-contrib-homekit-bridged",
-            "version": "1.7.0-dev.4",
+            "version": "1.7.0-dev.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@nrchkb/logger": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-homekit-bridged",
-    "version": "1.7.0-dev.4",
+    "version": "1.7.0-dev.5",
     "description": "Node-RED nodes to simulate Apple HomeKit devices.",
     "main": "build/nodes/nrchkb.js",
     "scripts": {


### PR DESCRIPTION
This PR allow empty value for `adaptiveLightingOptionsMode` and `adaptiveLightingOptionsCustomTemperatureAdjustment` inputs. This avoid existing nodes to flag an error.

This PR also adds default values ​​for these two properties. Indeed without this, existing nodes do not have a default value for these two new properties.

Bump also the dev version as requested on Discord.