### PR TITLE
Rename `config` to `nrchkbConfig` for isolation purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2024-10-11
+
+### Changed
+
+- Rename `config` to `nrchkbConfig` for isolation purpose
+
 ## [1.7.1] - 2024-09-24
 
 ### Fixed

--- a/build/nodes/nrchkb.html
+++ b/build/nodes/nrchkb.html
@@ -23,7 +23,7 @@
             dataType: 'json',
             async: false,
             success: function (data) {
-                config = data
+                nrchkbConfig = data
             },
         })
 
@@ -279,8 +279,8 @@
                     sortable: true
                 })
 
-                for (let i = 0; i < config.customCharacteristics.length; i++) {
-                    const customCharacteristic = config.customCharacteristics[i]
+                for (let i = 0; i < nrchkbConfig.customCharacteristics.length; i++) {
+                    const customCharacteristic = nrchkbConfig.customCharacteristics[i]
                     $('#node-input-customCharacteristics-container').editableList('addItem', customCharacteristic)
                 }
             },
@@ -312,7 +312,7 @@
     let accessoryCategories
     let nrchkbVersion = '0.0.0'
     let nrchkbExperimental = false
-    let config = []
+    let nrchkbConfig = {}
 
     //HomeKit Service Types
     $.getJSON('nrchkb/service/types', function (data) {
@@ -393,7 +393,7 @@
             })
         })
 
-        config.customCharacteristics = customCharacteristics
+        nrchkbConfig.customCharacteristics = customCharacteristics
 
         $.ajax({
             type: 'POST',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-red-contrib-homekit-bridged",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "node-red-contrib-homekit-bridged",
-            "version": "1.7.1",
+            "version": "1.7.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@nrchkb/logger": "~3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-homekit-bridged",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Node-RED nodes to simulate Apple HomeKit devices.",
     "main": "build/nodes/nrchkb.js",
     "scripts": {


### PR DESCRIPTION
The `nrchkb` node is not isolated which means that all variables in the top scope are global.

In order to avoid a variable duplication that prevents the `homekit-service` node from instantiating, I renamed `config` to `nrchkbConfig`. Because it's a common variable name.